### PR TITLE
Update cop-call.yang

### DIFF
--- a/yang/cop-call.yang
+++ b/yang/cop-call.yang
@@ -318,7 +318,7 @@ module cop-call {
         description "Basic Traffic Parameters to be offered within a Call";
         leaf reserved_bandwidth {
             description "Reserved Bandwidth measured in Mb/s i.e. 10, 100, 1000 Mb/s";
-            type int32;
+            type string;
         }
 		    leaf latency {
 			      description "Connection latency measured in ms";


### PR DESCRIPTION
This commit changes the data format of the "reservedBandwidth" parameter of the object "trafficParams" to String, in order to be complaint with the parameters: "unreservBw" and "maxResvBw", of object "Edge" in cop_topology model.